### PR TITLE
Baselines the MAINTAINERS.md and CODEOWNERS files.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,5 @@
-# This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-*   @opensearch-project/logstash-input-opensearch
+# This should match the list of maintainers in MAINTAINERS.md
+* @asifsmohammed
+* @sshivanii
+* @dlvenable
+* @oeyh

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,5 +6,15 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 | Maintainer             | GitHub ID                                             | Affiliation |
 | ---------------------- | ----------------------------------------------------- | ----------- |
+| Asif Sohail Mohammed | [asifsmohammed](https://github.com/asifsmohammed)     | Amazon      |
+| Shivani Shukla       | [sshivanii](https://github.com/sshivanii)             | Amazon      |
+| David Venable        | [dlvenable](https://github.com/dlvenable)             | Amazon      |
+| Hai Yan              | [oeyh](https://github.com/oeyh)                       | Amazon      |
+
+
+## Emeritus
+
+| Maintainer             | GitHub ID                                             | Affiliation |
+| ---------------------- | ----------------------------------------------------- | ----------- |
 | Naveen Tatikonda       | [naveentatikonda](https://github.com/naveentatikonda) | Amazon      |
 | Vamshi Vijay Nakkirtha | [vamshin](https://github.com/vamshin)                 | Amazon      |


### PR DESCRIPTION
### Description

This baselines the list of maintainers for the project. It also updates the CODEOWNERS file to use specific names. This is following the pattern supplied in https://github.com/opensearch-project/.github/issues/125 for correcting a repo.

### Issues Resolved

Resolves #45 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has documentation added
- [x] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
