### PR TITLE
Fixes CODEOWNERS by putting all on a single line. Updated MAINTAINERS.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,2 @@
 # This should match the list of maintainers in MAINTAINERS.md
-* @asifsmohammed
-* @sshivanii
-* @dlvenable
-* @oeyh
+* @asifsmohammed @dlvenable @oeyh

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,7 +7,6 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Maintainer             | GitHub ID                                             | Affiliation |
 | ---------------------- | ----------------------------------------------------- | ----------- |
 | Asif Sohail Mohammed | [asifsmohammed](https://github.com/asifsmohammed)     | Amazon      |
-| Shivani Shukla       | [sshivanii](https://github.com/sshivanii)             | Amazon      |
 | David Venable        | [dlvenable](https://github.com/dlvenable)             | Amazon      |
 | Hai Yan              | [oeyh](https://github.com/oeyh)                       | Amazon      |
 
@@ -16,5 +15,6 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 | Maintainer             | GitHub ID                                             | Affiliation |
 | ---------------------- | ----------------------------------------------------- | ----------- |
+| Shivani Shukla       | [sshivanii](https://github.com/sshivanii)             | Amazon      |
 | Naveen Tatikonda       | [naveentatikonda](https://github.com/naveentatikonda) | Amazon      |
 | Vamshi Vijay Nakkirtha | [vamshin](https://github.com/vamshin)                 | Amazon      |


### PR DESCRIPTION
### Description

Fixes the `CODEOWNERS` file by putting all users on a single line. Also, moves Shivani to Emeritus section.

See: https://github.com/opensearch-project/logstash-output-opensearch/pull/203#discussion_r1142562128


### Issues Resolved
N/A

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has documentation added
- [ ] Commits are signed as per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
